### PR TITLE
Expand StringExt dependency to support v0.15.x

### DIFF
--- a/src/Ar/CSVFileLib/ANSIC.lby
+++ b/src/Ar/CSVFileLib/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="1.02.2" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="1.02.3" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">CSVFileLib.typ</File>
     <File Description="Exported constants">CSVFileLib.var</File>
@@ -37,7 +37,7 @@
     <Dependency ObjectName="HMITools" FromVersion="0.11.3" ToVersion="0.11.9" />
     <Dependency ObjectName="runtime" />
     <Dependency ObjectName="standard" />
-    <Dependency ObjectName="StringExt" FromVersion="0.14.1" ToVersion="0.14.9" />
+    <Dependency ObjectName="StringExt" FromVersion="0.14.1" ToVersion="0.15.9" />
     <Dependency ObjectName="sys_lib" />
     <Dependency ObjectName="LogThat" FromVersion="0.05.0" ToVersion="0.05.9" />
     <Dependency ObjectName="AsBrStr" />

--- a/src/Ar/CSVFileLib/CHANGELOG.md
+++ b/src/Ar/CSVFileLib/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.2.3 - Expand StringExt dependency
+
 1.2.2 - Increase maximum size of variable list from 50 to 100
 
 1.2.1 - Fix internal variable usage


### PR DESCRIPTION
Expand StringExt dependency to support v0.15.x

StringExt v0.15.x is backwards-compatible with v0.14.x and should be allowed
