### PR TITLE
Actually disable logging if CFG.DisableLogging

### DIFF
--- a/src/Ar/CSVFileLib/ANSIC.lby
+++ b/src/Ar/CSVFileLib/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="1.02.3" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="1.02.4" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">CSVFileLib.typ</File>
     <File Description="Exported constants">CSVFileLib.var</File>

--- a/src/Ar/CSVFileLib/CHANGELOG.md
+++ b/src/Ar/CSVFileLib/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.2.4 - Do not create log file if CFG.DisableLogging is true
+
 1.2.3 - Expand StringExt dependency
 
 1.2.2 - Increase maximum size of variable list from 50 to 100

--- a/src/Ar/CSVFileLib/CSVFn_Cyclic.c
+++ b/src/Ar/CSVFileLib/CSVFn_Cyclic.c
@@ -637,10 +637,16 @@ switch( t->OUT.STAT.State ){
 			
 			case CSV_ERR_BUSY: t->Internal.ScanCount++; break;
 			
-			/* Other errors or all good - write log then check status again later */
+			/* Other errors or all good - write log (if not disabled) then check status again later */
 					
-			default: t->OUT.STAT.State=	CSV_ST_DELETELOG; break;
-			
+			default: 
+				
+				if(t->IN.CFG.DisableLogging){
+					t->OUT.STAT.State=	CSV_ST_IDLE; break;
+				}
+				else{
+					t->OUT.STAT.State=	CSV_ST_DELETELOG; break;
+				}
 			
 		} // switch(ProcessStatus) //
 		


### PR DESCRIPTION
## What:
Do not create the log file if disable logging is true.

## Why:

This configuration variable does not really do what it should in my opinion. I do not want to see a log file if I set this true.